### PR TITLE
Set time for book/value date to 00:00:00, instead of loading time.

### DIFF
--- a/lib/Jejik/MT940/Parser/AbstractParser.php
+++ b/lib/Jejik/MT940/Parser/AbstractParser.php
@@ -283,6 +283,8 @@ abstract class AbstractParser
 
         // Parse dates
         $valueDate = \DateTime::createFromFormat('ymd', $match[1]);
+        $valueDate->setTime(0,0,0);
+        
         $bookDate = null;
 
         if ($match[2]) {
@@ -292,6 +294,7 @@ abstract class AbstractParser
             if ((int) $bookDate->format('Y') < (int) $valueDate->format('Y')) {
                 $bookDate->modify('+1 year');
             }
+            $bookDate->setTime(0,0,0);
         }
 
         $description = isset($lines[1]) ? $lines[1] : null;


### PR DESCRIPTION
There are no times available // loaded from the file, so it is meaningless to save it against current time. For comparison of transactions etc it would be better if they're set to 00:00:00. No tests need to be changed for this behaviour as far as I know.
