### PR TITLE
According to documentation balance can also be " :62M: ".

### DIFF
--- a/lib/Jejik/MT940/Parser/AbstractParser.php
+++ b/lib/Jejik/MT940/Parser/AbstractParser.php
@@ -247,6 +247,8 @@ abstract class AbstractParser
     {
         if ($line = $this->getLine('60F', $text)) {
             return $this->balance($line);
+        }elseif  ($line = $this->getLine('60M', $text)) {
+        	return $this->balance($line);        	
         }
     }
 
@@ -260,6 +262,8 @@ abstract class AbstractParser
     {
         if ($line = $this->getLine('62F', $text)) {
             return $this->balance($line);
+        }elseif  ($line = $this->getLine('62M', $text)) {
+        	return $this->balance($line);        	
         }
     }
 


### PR DESCRIPTION
Start and end balance was only identified by ":60F:" and ":62F:".
According to http://nl.wikipedia.org/wiki/MT940 (bad source, I know),
but also http://www.abnamro.nl/nl/images/Generiek/PDFs/020_Zakelijk/03_OfficeNet/Formatenboek_MT94_(nederlands).pdf
(dutch only, sorry), you can also expect ":60M:" and ":62M:".
From that pdf:

60m     Tag 60m Opening balance         :60m: m = F or M
62m     Tag 62m (booked funds)          :62m: m = F or M
