### PR TITLE
ABN needs a trim on GIRO accounts

### DIFF
--- a/lib/Jejik/MT940/Parser/AbnAmro.php
+++ b/lib/Jejik/MT940/Parser/AbnAmro.php
@@ -52,7 +52,7 @@ class AbnAmro extends AbstractParser
         }
 
         if (preg_match('/^GIRO([0-9 ]{9}) /', $lines[1], $match)) {
-            return $match[1];
+            return trim($match[1]);
         }
 
         return null;


### PR DESCRIPTION
Giro accounts are padded with some spaces. I don't know if this was deliberate, but it seems unnecessary? If there was some reason I didn't get, sorry :)
