### PR TITLE
Fix issue with :86: lines ending in whitespace

### DIFF
--- a/lib/Jejik/MT940/Parser/AbstractParser.php
+++ b/lib/Jejik/MT940/Parser/AbstractParser.php
@@ -69,7 +69,7 @@ abstract class AbstractParser
         // Offset manually, so the start of the offset can match ^
         if (preg_match($pcre, substr($text, $offset), $match, PREG_OFFSET_CAPTURE)) {
             $position = $offset + $match[1][1] - 1;
-            return rtrim($match[2][0]);
+            return rtrim($match[2][0],"\t\n\r\0\x0B");
         }
 
         return '';


### PR DESCRIPTION
Lines can have a space, but they are discarded. This would mean the position would be wrong after the rtrim, and a line would be skipped by the reg-exp. I'm not sure the characters that are stripped are actually there, but to be as close to the current code I have just removed the space character.
Testdata (MT940) can be send upon request.
