### PR TITLE
fix credit bug

### DIFF
--- a/lib/Jejik/MT940/Parser/AbstractParser.php
+++ b/lib/Jejik/MT940/Parser/AbstractParser.php
@@ -316,7 +316,7 @@ abstract class AbstractParser
 
         // Parse the amount
         $amount = (float) str_replace(',', '.', $match[4]);
-        if (in_array($match[3], array('D', 'CR'))) {
+        if (in_array($match[3], array('D', 'DR'))) {
             $amount *= -1;
         }
 


### PR DESCRIPTION
The default parser seems invert signs when CR rather than C is used to signify a credit.
