### PR TITLE
Fix for bookdates before valuedates around januari 1st.

### DIFF
--- a/lib/Jejik/MT940/Parser/AbstractParser.php
+++ b/lib/Jejik/MT940/Parser/AbstractParser.php
@@ -328,12 +328,12 @@ abstract class AbstractParser
 
         if ($match[2]) {
             $bookDate = \DateTime::createFromFormat('ymd', $valueDate->format('y') . $match[2]);
+            $bookDate->setTime(0,0,0);
 
             // Handle bookdate in the next year. E.g. valueDate = dec 31, bookDate = jan 2
             if ($bookDate < $valueDate) {
                 $bookDate->modify('+1 year');
             }
-            $bookDate->setTime(0,0,0);
         }
 
         $description = isset($lines[1]) ? $lines[1] : null;

--- a/lib/Jejik/MT940/Parser/AbstractParser.php
+++ b/lib/Jejik/MT940/Parser/AbstractParser.php
@@ -330,7 +330,7 @@ abstract class AbstractParser
             $bookDate = \DateTime::createFromFormat('ymd', $valueDate->format('y') . $match[2]);
 
             // Handle bookdate in the next year. E.g. valueDate = dec 31, bookDate = jan 2
-            if ((int) $bookDate->format('Y') < (int) $valueDate->format('Y')) {
+            if ($bookDate < $valueDate) {
                 $bookDate->modify('+1 year');
             }
             $bookDate->setTime(0,0,0);


### PR DESCRIPTION
The comparison of the year of the dates was moot as they were set to equal a few lines earlier. This resulted in wrong bookdates.

By moving the setTime line directly after creating the book date, the comparison of both \DateTime objects can be used and will properly update the bookdate if it actually is before the value date.