### PR TITLE
Update that will more correctly find the book date.

### DIFF
--- a/lib/Jejik/MT940/Parser/AbstractParser.php
+++ b/lib/Jejik/MT940/Parser/AbstractParser.php
@@ -212,7 +212,7 @@ abstract class AbstractParser
                   ->setClosingBalance($this->closingBalance($text));
 
         foreach ($this->splitTransactions($text) as $chunk) {
-            $statement->addTransaction($this->transaction($chunk, $statement));
+            $statement->addTransaction($this->transaction($chunk));
         }
 
         return $statement;
@@ -306,10 +306,9 @@ abstract class AbstractParser
      * Create a Transaction from MT940 transaction text lines
      *
      * @param array $lines The transaction text at offset 0 and the description at offset 1
-     * @param StatementInterface|null $statement Used to create a more accurate prediction of book date.
      * @return \Jejik\MT940\Transaction
      */
-    protected function transaction(array $lines, StatementInterface $statement = null)
+    protected function transaction(array $lines)
     {
         if (!preg_match('/(\d{6})((\d{2})(\d{2}))?((?:C|D)R?)([0-9,]{1,15})/', $lines[0], $match)) {
             throw new \RuntimeException(sprintf('Could not parse transaction line "%s"', $lines[0]));

--- a/lib/Jejik/MT940/Parser/AbstractParser.php
+++ b/lib/Jejik/MT940/Parser/AbstractParser.php
@@ -332,22 +332,6 @@ abstract class AbstractParser
             $month = intval($match[3]);
             $day = intval($match[4]);
             $bookDate = $this->getNearestDateTimeFromDayAndMonth($valueDate, $day, $month);
-
-            // If we know the opening date of our statement, we can coerce our book date forward if needed.
-            $statementOpeningDate = $statement->getOpeningBalance()->getDate();
-            if ($statementOpeningDate !== null) {
-                while ($bookDate < $statementOpeningDate) {
-                    $bookDate->modify('+1 year');
-                }
-            }
-
-            // Equally so for our end date.
-            $statementClosingDate = $statement->getClosingBalance()->getDate();
-            if ($statementClosingDate !== null) {
-                while ($bookDate > $statementClosingDate) {
-                    $bookDate->modify('-1 year');
-                }
-            }
         }
 
         $description = isset($lines[1]) ? $lines[1] : null;

--- a/lib/Jejik/MT940/Parser/AbstractParser.php
+++ b/lib/Jejik/MT940/Parser/AbstractParser.php
@@ -212,7 +212,7 @@ abstract class AbstractParser
                   ->setClosingBalance($this->closingBalance($text));
 
         foreach ($this->splitTransactions($text) as $chunk) {
-            $statement->addTransaction($this->transaction($chunk));
+            $statement->addTransaction($this->transaction($chunk, $statement));
         }
 
         return $statement;
@@ -306,17 +306,18 @@ abstract class AbstractParser
      * Create a Transaction from MT940 transaction text lines
      *
      * @param array $lines The transaction text at offset 0 and the description at offset 1
+     * @param StatementInterface|null $statement Used to create a more accurate prediction of book date.
      * @return \Jejik\MT940\Transaction
      */
-    protected function transaction(array $lines)
+    protected function transaction(array $lines, StatementInterface $statement = null)
     {
-        if (!preg_match('/(\d{6})(\d{4})?((?:C|D)R?)([0-9,]{1,15})/', $lines[0], $match)) {
+        if (!preg_match('/(\d{6})((\d{2})(\d{2}))?((?:C|D)R?)([0-9,]{1,15})/', $lines[0], $match)) {
             throw new \RuntimeException(sprintf('Could not parse transaction line "%s"', $lines[0]));
         }
 
         // Parse the amount
-        $amount = (float) str_replace(',', '.', $match[4]);
-        if (in_array($match[3], array('D', 'DR'))) {
+        $amount = (float) str_replace(',', '.', $match[6]);
+        if (in_array($match[5], array('D', 'DR'))) {
             $amount *= -1;
         }
 
@@ -327,12 +328,25 @@ abstract class AbstractParser
         $bookDate = null;
 
         if ($match[2]) {
-            $bookDate = \DateTime::createFromFormat('ymd', $valueDate->format('y') . $match[2]);
-            $bookDate->setTime(0,0,0);
+            // Construct book date from the month and day provided by adding the year of the value date as best guess.
+            $month = intval($match[3]);
+            $day = intval($match[4]);
+            $bookDate = $this->getNearestDateTimeFromDayAndMonth($valueDate, $day, $month);
 
-            // Handle bookdate in the next year. E.g. valueDate = dec 31, bookDate = jan 2
-            if ($bookDate < $valueDate) {
-                $bookDate->modify('+1 year');
+            // If we know the opening date of our statement, we can coerce our book date forward if needed.
+            $statementOpeningDate = $statement->getOpeningBalance()->getDate();
+            if ($statementOpeningDate !== null) {
+                while ($bookDate < $statementOpeningDate) {
+                    $bookDate->modify('+1 year');
+                }
+            }
+
+            // Equally so for our end date.
+            $statementClosingDate = $statement->getClosingBalance()->getDate();
+            if ($statementClosingDate !== null) {
+                while ($bookDate > $statementClosingDate) {
+                    $bookDate->modify('-1 year');
+                }
             }
         }
 
@@ -345,6 +359,42 @@ abstract class AbstractParser
                     ->setDescription($this->description($description));
 
         return $transaction;
+    }
+
+    /**
+     * Finds the closest \DateTime to the given target \DateTime with the set day and month.
+     * Will try at most 3 \Datetime's, one a year before our initial guess, and one a year after.
+     * Returns the one with the least days difference in days.
+     *
+     * @param \DateTime $target
+     * @param int $day
+     * @param int $month
+     * @return \DateTime
+     */
+    protected function getNearestDateTimeFromDayAndMonth(\DateTime $target, $day, $month)
+    {
+        $initialGuess = new \DateTime();
+        $initialGuess->setDate($target->format('Y'), $month, $day);
+        $initialGuess->setTime(0,0,0);
+        $initialGuessDiff = $target->diff($initialGuess);
+
+        $yearEarlier = clone $initialGuess;
+        $yearEarlier->modify('-1 year');
+        $yearEarlierDiff = $target->diff($yearEarlier);
+
+        if ($yearEarlierDiff->days < $initialGuessDiff->days) {
+            return $yearEarlier;
+        }
+
+        $yearLater = clone $initialGuess;
+        $yearLater->modify('+1 year');
+        $yearLaterDiff = $target->diff($yearLater);
+
+        if ($yearLaterDiff->days < $initialGuessDiff->days) {
+            return $yearLater;
+        }
+
+        return $initialGuess;
     }
 
     /**

--- a/lib/Jejik/MT940/Parser/Ing.php
+++ b/lib/Jejik/MT940/Parser/Ing.php
@@ -12,6 +12,8 @@
 
 namespace Jejik\MT940\Parser;
 
+use Jejik\MT940\StatementInterface;
+
 /**
  * Parser for ING documents
  *

--- a/lib/Jejik/MT940/Parser/Ing.php
+++ b/lib/Jejik/MT940/Parser/Ing.php
@@ -12,8 +12,6 @@
 
 namespace Jejik\MT940\Parser;
 
-use Jejik\MT940\StatementInterface;
-
 /**
  * Parser for ING documents
  *
@@ -57,12 +55,11 @@ class Ing extends AbstractParser
      * ING does sometimes supplies a book date inside the description.
      *
      * @param array $lines The transaction text at offset 0 and the description at offset 1
-     * @param StatementInterface|null $statement Used to create a more accurate prediction of book date.
      * @return \Jejik\MT940\Transaction
      */
-    protected function transaction(array $lines, StatementInterface $statement = null)
+    protected function transaction(array $lines)
     {
-        $transaction = parent::transaction($lines, $statement);
+        $transaction = parent::transaction($lines);
         $transaction->setBookDate($transaction->getValueDate())
                     ->setValueDate(null);
 

--- a/lib/Jejik/MT940/Parser/Ing.php
+++ b/lib/Jejik/MT940/Parser/Ing.php
@@ -55,11 +55,12 @@ class Ing extends AbstractParser
      * ING does sometimes supplies a book date inside the description.
      *
      * @param array $lines The transaction text at offset 0 and the description at offset 1
+     * @param StatementInterface|null $statement Used to create a more accurate prediction of book date.
      * @return \Jejik\MT940\Transaction
      */
-    protected function transaction(array $lines)
+    protected function transaction(array $lines, StatementInterface $statement = null)
     {
-        $transaction = parent::transaction($lines);
+        $transaction = parent::transaction($lines, $statement);
         $transaction->setBookDate($transaction->getValueDate())
                     ->setValueDate(null);
 


### PR DESCRIPTION
- Add method to find the nearest `\DateTime` to a target `\DateTime` and a given month and day.
- Use of this method to locate the most likely (closest) book date for a given value date.
- ~Ability to optionally pass a `StatementInterface` to `transaction` method, to ensure the book date is within the statement date boundaries.~
- ~Updated `IngParser` to adhere to the new method signature.~

**edit**: Removed the passing of the `StatementInterface` to the `transaction` method as not all banks adhere to only exporting transactions with book dates between the opening and closing balance dates.