### PR TITLE
Parse transaction supplementary details for German banks

### DIFF
--- a/lib/Jejik/MT940/Parser/AbstractParser.php
+++ b/lib/Jejik/MT940/Parser/AbstractParser.php
@@ -471,6 +471,7 @@ abstract class AbstractParser
             ->setCode($this->code($lines))
             ->setRef($this->ref($lines))
             ->setBankRef($this->bankRef($lines))
+            ->setSupplementaryDetails($this->supplementaryDetails($lines))
             ->setGVC($this->gvc($lines))
             ->setTxText($this->txText($lines))
             ->setPrimanota($this->primanota($lines))
@@ -578,6 +579,14 @@ abstract class AbstractParser
      * Parse bankRef for provided transaction lines
      */
     protected function bankRef(array $lines): ?string
+    {
+        return null;
+    }
+
+    /**
+     * Parse supplementary details
+     */
+    protected function supplementaryDetails(array $lines): ?string
     {
         return null;
     }

--- a/lib/Jejik/MT940/Parser/GermanBank.php
+++ b/lib/Jejik/MT940/Parser/GermanBank.php
@@ -75,6 +75,18 @@ abstract class GermanBank extends AbstractParser
     }
 
     /**
+     * Parse supplementary details
+     */
+    protected function supplementaryDetails(array $lines): ?string
+    {
+        $refLine = isset($lines[0]) ? $lines[0] : null;
+
+        $parts = preg_split("/\\r\\n|\\r|\\n/", $refLine, 2);
+
+        return isset($parts[1]) ? $parts[1] : null;
+    }
+
+    /**
      * Parse ref for provided transaction lines
      */
     protected function ref(array $lines): ?string

--- a/lib/Jejik/MT940/Transaction.php
+++ b/lib/Jejik/MT940/Transaction.php
@@ -66,6 +66,11 @@ class Transaction implements TransactionInterface
     /**
      * @var string
      */
+    private $supplementaryDetails;
+
+    /**
+     * @var string
+     */
     private $gvc;
 
     /**
@@ -262,6 +267,25 @@ class Transaction implements TransactionInterface
     public function setBankRef(string $bankRef = null): TransactionInterface
     {
         $this->bankRef = $bankRef;
+        return $this;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getSupplementaryDetails(): ?string
+    {
+        return $this->supplementaryDetails;
+    }
+
+    /**
+     * @param string|null $supplementaryDetails
+     * @return TransactionInterface
+     */
+    public function setSupplementaryDetails(?string $supplementaryDetails): TransactionInterface
+    {
+        $this->supplementaryDetails = $supplementaryDetails;
+
         return $this;
     }
 

--- a/lib/Jejik/MT940/TransactionInterface.php
+++ b/lib/Jejik/MT940/TransactionInterface.php
@@ -102,6 +102,16 @@ interface TransactionInterface
     public function setBankRef(string $bankRef = null): TransactionInterface;
 
     /**
+     * Set supplementary details
+     */
+    public function setSupplementaryDetails(?string $supplementaryDetails): TransactionInterface;
+
+    /**
+     * Get supplementary details
+     */
+    public function getSupplementaryDetails(): ?string;
+
+    /**
      * Get GVC for this transaction
      */
     public function getGVC(): ?string;

--- a/tests/Jejik/Tests/MT940/Parser/DeutscheBankTest.php
+++ b/tests/Jejik/Tests/MT940/Parser/DeutscheBankTest.php
@@ -75,6 +75,7 @@ EF+2?230852HW2723821 CRED+DE41EON0?240000129793 OAMT+11,85 SVWZ+?\r
         $this->assertNull($transactions[0]->getCode());
         $this->assertEquals('KREF+', $transactions[0]->getRef());
         $this->assertEquals('2016021783252833', $transactions[0]->getBankRef());
+        $this->assertEquals('/OCMT/EUR11,85//CHGS/EUR0,50/', $transactions[0]->getSupplementaryDetails());
 
         $this->assertEquals('109', $transactions[0]->getGVC());
         $this->assertEquals('SEPA-LASTSCHR. RETOURE CORE', $transactions[0]->getTxText());


### PR DESCRIPTION
Parse transaction supplementary details for German banks.
Please merge this, I need it for my integration.

That is according to https://www.sepaforcorporates.com/swift-for-corporates/account-statement-mt940-file-format-overview/

<img width="565" alt="supplementary details section" src="https://user-images.githubusercontent.com/864822/127308192-cd620b0f-b2ee-4942-b6ba-f7e2509b650f.png">
