### PR TITLE
Move reference extraction logic from the German bank abstract class to the general abstract class

### DIFF
--- a/lib/Jejik/MT940/Parser/AbstractParser.php
+++ b/lib/Jejik/MT940/Parser/AbstractParser.php
@@ -582,7 +582,18 @@ abstract class AbstractParser
      */
     protected function ref(array $lines): ?string
     {
-        return null;
+        $refLine = $lines[0] ?? null;
+
+        // assure ref line
+        if ($refLine == null) {
+            return null;
+        }
+
+        // match it
+        preg_match("/(?'valuta'\d{6})(?'bookingdate'\d{4})?(?'debitcreditid'R?(?:C|D))(?'amount'[0-9,]{1,15})(?:\s*)(?'bookingkey'N[a-zA-Z0-9]{3})(?'reference'[a-zA-Z0-9+]+)(?:\/\/)*(?'bankref'[0-9a-zA-Z]{1,16})*/", $refLine, $match);
+
+        // assure match
+        return $match['reference'] ?? null;
     }
 
     /**
@@ -590,7 +601,18 @@ abstract class AbstractParser
      */
     protected function bankRef(array $lines): ?string
     {
-        return null;
+        $refLine = $lines[0] ?? null;
+
+        // assure ref line
+        if ($refLine == null) {
+            return null;
+        }
+
+        // match it
+        preg_match("/(?'valuta'\d{6})(?'bookingdate'\d{4})?(?'debitcreditid'R?(?:C|D))(?'amount'[0-9,]{1,15})(?:\s*)(?'bookingkey'N[a-zA-Z0-9]{3})(?'reference'[a-zA-Z0-9+]+)(?:\/\/)*(?'bankref'[0-9a-zA-Z]{1,16})*/", $refLine, $match);
+
+        // assure match
+        return $match['bankref'] ?? null;
     }
 
     /**

--- a/lib/Jejik/MT940/Parser/GermanBank.php
+++ b/lib/Jejik/MT940/Parser/GermanBank.php
@@ -87,44 +87,6 @@ abstract class GermanBank extends AbstractParser
     }
 
     /**
-     * Parse ref for provided transaction lines
-     */
-    protected function ref(array $lines): ?string
-    {
-        $refLine = $lines[0] ?? null;
-
-        // assure ref line
-        if ($refLine == null) {
-            return null;
-        }
-
-        // match it
-        preg_match("/(?'valuta'\d{6})(?'bookingdate'\d{4})?(?'debitcreditid'R?(?:C|D))(?'amount'[0-9,]{1,15})(?:\s*)(?'bookingkey'N[a-zA-Z0-9]{3})(?'reference'[a-zA-Z0-9+]+)(?:\/\/)*(?'bankref'[0-9a-zA-Z]{1,16})*/", $refLine, $match);
-
-        // assure match
-        return $match['reference'] ?? null;
-    }
-
-    /**
-     * Parse bankRef for provided transaction lines
-     */
-    protected function bankRef(array $lines): ?string
-    {
-        $refLine = $lines[0] ?? null;
-
-        // assure ref line
-        if ($refLine == null) {
-            return null;
-        }
-
-        // match it
-        preg_match("/(?'valuta'\d{6})(?'bookingdate'\d{4})?(?'debitcreditid'R?(?:C|D))(?'amount'[0-9,]{1,15})(?:\s*)(?'bookingkey'N[a-zA-Z0-9]{3})(?'reference'[a-zA-Z0-9+]+)(?:\/\/)*(?'bankref'[0-9a-zA-Z]{1,16})*/", $refLine, $match);
-
-        // assure match
-        return $match['bankref'] ?? null;
-    }
-
-    /**
      * Parse txText for provided transaction lines
      */
     protected function txText(array $lines): ?string


### PR DESCRIPTION
The logic for getting the references from the statement line (:61:) was defined in the GermanBank class, which German bank parsers extend.

Since Dutch banks use the identical statement line structure, this same logic can be used to extract these references from their statements as well.

This means the logic can be moved from the GermanBank class to the AbstractParser class, which is the base for all bank parsers, both German and Dutch banks.