### PR TITLE
Add RaiffeisenKaernten parser and corresponding tests

### DIFF
--- a/lib/Jejik/MT940/Parser/RaiffeisenKaernten.php
+++ b/lib/Jejik/MT940/Parser/RaiffeisenKaernten.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Jejik\MT940 library
+ *
+ * Copyright (c) 2025 Lars Riße - chargecloud GmbH
+ * Licensed under the MIT license
+ *
+ * For the full copyright and license information, please see the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Jejik\MT940\Parser;
+
+/**
+ * Class RaiffeisenKaernten
+ *
+ * @package Jejik\MT940\Parser
+ */
+class RaiffeisenKaernten extends GermanBank
+{
+    /** @inheritDoc */
+    public function getAllowedBLZ(): array
+    {
+        return ['AT39364'];
+    }
+
+    /** @inheritDoc */
+    public function accept(string $text): bool
+    {
+        return $this->isBLZAllowed($text);
+    }
+
+    /** @inheritDoc */
+    public function isBLZAllowed($text): bool
+    {
+        $this->checkCRLF($text);
+
+        $account = $this->getLine('25', $text);
+
+        if ($account === null) {
+            return false;
+        }
+
+        $accountExploded = explode('/', $account);
+
+        return isset($accountExploded[2]) && \in_array($accountExploded[2], $this->getAllowedBLZ(), true);
+    }
+
+    /** @inheritDoc */
+    protected function accountNumber(string $text): ?string
+    {
+        $accountNumber = parent::accountNumber($text);
+
+        return str_replace(['//', '/EUR'], '', $accountNumber);
+    }
+}

--- a/lib/Jejik/MT940/Reader.php
+++ b/lib/Jejik/MT940/Reader.php
@@ -50,6 +50,7 @@ class Reader
         'PostFinance' => Parser\PostFinance::class,
         'Rabobank'    => Parser\Rabobank::class,
         'Raiffeisen' => Parser\Raiffeisen::class,
+        'RaiffeisenKaernten' => Parser\RaiffeisenKaernten::class,
         'Sns'         => Parser\Sns::class,
         'Solaris' => Parser\Solaris::class,
         'Sparkasse'   => Parser\Sparkasse::class,

--- a/tests/Jejik/Tests/MT940/Fixture/document/raiffeisen-kaernten.txt
+++ b/tests/Jejik/Tests/MT940/Fixture/document/raiffeisen-kaernten.txt
@@ -1,0 +1,15 @@
+:20:20250717000000
+:21:12345678912345
+:25://AT39364/12345678912/EUR
+:28C:25001/001
+:60F:C250716EUR0,00
+:61:2507160716C1,00NTRFNONREF
+:86:999foo
+Test Überweisung
+:62F:C250716EUR1,00
+:86:Dieses Konto ist im Rahmen der gesetzlichen Einlagensicherung
+erstattungsfähig. Der Informationsbogen liegt in der Bank bereit
+und
+ist auf der Homepage Ihrer Bank abrufbar. Unsere Berater:innen
+stehen Ihnen gerne für weitere Fragen zur Verfügung
+IBAN: xx / BIC: xx

--- a/tests/Jejik/Tests/MT940/Parser/RaiffeisenKaerntenTest.php
+++ b/tests/Jejik/Tests/MT940/Parser/RaiffeisenKaerntenTest.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace Jejik\Tests\MT940\Parser;
+
+use Jejik\MT940\Balance;
+use Jejik\MT940\Parser\RaiffeisenKaernten;
+use Jejik\MT940\Reader;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Class RaiffeisenKaerntenTest
+ *
+ * @package Jejik\Tests\MT940\Parser
+ */
+class RaiffeisenKaerntenTest extends TestCase
+{
+    /** @var Reader */
+    private $reader;
+
+    /** @inheritDoc */
+    protected function setUp(): void
+    {
+        $this->reader = new Reader();
+        $this->reader->addParser('RaiffeisenKaernten', RaiffeisenKaernten::class);
+    }
+
+    /**
+     * @return void
+     *
+     * @dataProvider acceptTestDataProvider
+     */
+    public function testAccept(string $text, bool $expected): void
+    {
+        $parser = new RaiffeisenKaernten($this->reader);
+
+        $this->assertEquals($expected, $parser->accept($text));
+    }
+
+    public function acceptTestDataProvider(): array
+    {
+        return [
+            ['text' => file_get_contents(__DIR__ . '/../Fixture/document/raiffeisen-kaernten.txt'), 'expected' => true],
+            ['text' => file_get_contents(__DIR__ . '/../Fixture/document/raiffeisen.txt'), 'expected' => false],
+            ['text' => file_get_contents(__DIR__ . '/../Fixture/document/bil.txt'), 'expected' => false],
+            ['text' => file_get_contents(__DIR__ . '/../Fixture/document/ing-4.txt'), 'expected' => false],
+            ['text' => file_get_contents(__DIR__ . '/../Fixture/document/ing-dos.txt'), 'expected' => false],
+            ['text' => file_get_contents(__DIR__ . '/../Fixture/document/sparkasse.txt'), 'expected' => false],
+            ['text' => file_get_contents(__DIR__ . '/../Fixture/document/sparkasse2.txt'), 'expected' => false],
+            ['text' => file_get_contents(__DIR__ . '/../Fixture/document/triodos.txt'), 'expected' => false],
+        ];
+    }
+
+    public function testStatement(): void
+    {
+        $statements = $this->reader->getStatements(file_get_contents(__DIR__ . '/../Fixture/document/raiffeisen-kaernten.txt'));
+
+        $this->assertCount(1, $statements, 'Assert counting statements.');
+        $statement = $statements[0];
+
+        $this->assertEquals('25001/001', $statement->getNumber());
+        $this->assertEquals('AT39364/12345678912', $statement->getAccount()->getNumber());
+    }
+
+    public function testBalance(): void
+    {
+        $statements = $this->reader->getStatements(file_get_contents(__DIR__ . '/../Fixture/document/raiffeisen-kaernten.txt'));
+
+        $balance = $statements[0]->getOpeningBalance();
+        $this->assertInstanceOf(Balance::class, $balance);
+        $this->assertEquals('2025-07-16 00:00:00', $balance->getDate()->format('Y-m-d H:i:s'));
+        $this->assertEquals('EUR', $balance->getCurrency());
+        $this->assertEquals(0, $balance->getAmount());
+    }
+
+    public function testTransaction(): void
+    {
+        $statements = $this->reader->getStatements(file_get_contents(__DIR__ . '/../Fixture/document/raiffeisen-kaernten.txt'));
+
+        $transactions = $statements[0]->getTransactions();
+
+        $this->assertCount(1, $transactions);
+        $this->assertNull($transactions[0]->getContraAccount());
+
+        $this->assertEquals(1, $transactions[0]->getAmount());
+        $expectedDescription =
+            "999foo\r
+Test Überweisung";
+        $this->assertEquals($expectedDescription, $transactions[0]->getDescription());
+        $this->assertEquals('2025-07-16 00:00:00', $transactions[0]->getValueDate()->format('Y-m-d H:i:s'), 'Assert Value Date');
+        $this->assertEquals('2025-07-16 00:00:00', $transactions[0]->getBookDate()->format('Y-m-d H:i:s'), 'Assert Book Date');
+
+        $this->assertEquals('TRF', $transactions[0]->getCode());
+        $this->assertEquals('NONREF', $transactions[0]->getRef());
+        $this->assertNull($transactions[0]->getBankRef());
+
+        $this->assertEquals('999', $transactions[0]->getGVC());
+        $this->assertNull($transactions[0]->getTxText());
+        $this->assertNull($transactions[0]->getPrimanota());
+        $this->assertNull($transactions[0]->getExtCode());
+
+        $this->assertNull($transactions[0]->getEref());
+
+        $this->assertNull($transactions[0]->getBIC());
+        $this->assertNull($transactions[0]->getIBAN());
+        $this->assertNull($transactions[0]->getAccountHolder());
+
+        $this->assertNull($transactions[0]->getKref());
+        $this->assertNull($transactions[0]->getMref());
+        $this->assertNull($transactions[0]->getCred());
+        $this->assertNull($transactions[0]->getSvwz());
+        $this->assertNull($transactions[0]->getRawSubfieldsData());
+    }
+}

--- a/tests/Jejik/Tests/MT940/ReaderTest.php
+++ b/tests/Jejik/Tests/MT940/ReaderTest.php
@@ -39,7 +39,7 @@ class ReaderTest extends TestCase
             $this->assertTrue($e->getMessage() === 'No text is found for parsing.');
         }
 
-        $this->assertCount(22, $reader->getDefaultParsers());
+        $this->assertCount(23, $reader->getDefaultParsers());
     }
 
     public function testAddParser()


### PR DESCRIPTION
This PR adds a new parser for the Austrian Raiffaisen Bank Kaernten, as well as the associated tests. Unfortunately, only one reference account statement was available for implementation.